### PR TITLE
Allow system-wide installation of innosetup installer

### DIFF
--- a/Installer.iss
+++ b/Installer.iss
@@ -23,8 +23,8 @@ AppUpdatesURL={#MyAppURL}
 DefaultDirName={autopf}\{#MyAppName}
 DisableProgramGroupPage=yes
 ; Uncomment the following line to run in non administrative install mode (install for current user only.)
-PrivilegesRequired=lowest
-;PrivilegesRequiredOverridesAllowed=dialog
+; PrivilegesRequired=lowest
+PrivilegesRequiredOverridesAllowed=dialog
 OutputBaseFilename={#OutputBaseFileName}
 Compression=lzma
 SolidCompression=yes


### PR DESCRIPTION
Some would want to have MicaForEveryone installed system-wide:
![image](https://user-images.githubusercontent.com/56180050/180641464-70b6a102-1fee-4449-a137-325e260ed3a6.png)
