### PR TITLE
Update Winget Releaser workflow

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -8,7 +8,7 @@ jobs:
   publish:
     runs-on: windows-latest
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@latest
+      - uses: vedantmgoyal2009/winget-releaser@v1
         with:
           identifier: MicaForEveryone.MicaForEveryone
           installers-regex: 'MicaForEveryone-\w+-Release-Installer\.exe$'


### PR DESCRIPTION
Winget Releaser now uses versioned tags instead of the `latest` tag.