### PR TITLE
[Experiment] update get-version-action dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         fetch-depth: 0
     - name: Get Version
       id: get_version
-      uses: MicaForEveryone/get-version-action@v2.3.0
+      uses: MicaForEveryone/get-version-action@v2.3.1
       if: startsWith(github.ref, 'refs/tags/v')
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.3
@@ -76,7 +76,7 @@ jobs:
         fetch-depth: 0
     - name: Get Version
       id: get_version
-      uses: MicaForEveryone/get-version-action@v2.3.0
+      uses: MicaForEveryone/get-version-action@v2.3.1
       if: startsWith(github.ref, 'refs/tags/v')
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         fetch-depth: 0
     - name: Get Version
       id: get_version
-      uses: battila7/get-version-action@v2
+      uses: MicaForEveryone/get-version-action@v2
       if: startsWith(github.ref, 'refs/tags/v')
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.3
@@ -76,7 +76,7 @@ jobs:
         fetch-depth: 0
     - name: Get Version
       id: get_version
-      uses: battila7/get-version-action@v2
+      uses: MicaForEveryone/get-version-action@v2
       if: startsWith(github.ref, 'refs/tags/v')
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         fetch-depth: 0
     - name: Get Version
       id: get_version
-      uses: MicaForEveryone/get-version-action@v2
+      uses: MicaForEveryone/get-version-action@v2.3.0
       if: startsWith(github.ref, 'refs/tags/v')
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.3
@@ -76,7 +76,7 @@ jobs:
         fetch-depth: 0
     - name: Get Version
       id: get_version
-      uses: MicaForEveryone/get-version-action@v2
+      uses: MicaForEveryone/get-version-action@v2.3.0
       if: startsWith(github.ref, 'refs/tags/v')
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.3


### PR DESCRIPTION
Hopefully it should remove outdated warnings.