### PR TITLE
Support for .NET 6 and SupportedOSPlatform attributes

### DIFF
--- a/MicaForEveryone.UI/SettingsView.xaml.cs
+++ b/MicaForEveryone.UI/SettingsView.xaml.cs
@@ -21,6 +21,7 @@ namespace MicaForEveryone.UI
             new Contributor("Dongle the Gadget", "https://github.com/dongle-the-gadget", null),
             new Contributor("sitiom", "https://github.com/sitiom", null),
             new Contributor("krlvm", "https://github.com/krlvm", null),
+            new Contributor("TheXDS", "https://github.com/TheXDS", null),
         };
 
         internal Contributor[] Translators { get; } =

--- a/MicaForEveryone.Win32/DesktopWindowManager.cs
+++ b/MicaForEveryone.Win32/DesktopWindowManager.cs
@@ -1,21 +1,12 @@
-﻿using System;
+﻿using MicaForEveryone.Win32.PInvoke;
+using System;
 using System.Runtime.InteropServices;
-
-using MicaForEveryone.Win32.PInvoke;
-
 using static MicaForEveryone.Win32.PInvoke.NativeMethods;
 
 namespace MicaForEveryone.Win32
 {
     public static class DesktopWindowManager
     {
-        private const uint DWMWA_MICA = 1029;
-        private const uint DWMWA_IMMERSIVE_DARK_MODE = 20;
-        private const uint DWMWA_SYSTEMBACKDROP_TYPE = 38;
-        private const uint DWMWA_WINDOW_CORNER_PREFERENCE = 33;
-        private const uint DWMWA_CAPTION_COLOR = 35;
-        private const uint DWMWA_TEXT_COLOR = 36;
-
         /// <summary>
         /// Check whether Windows build is 19041 or higher, that supports <see cref="SetImmersiveDarkMode(IntPtr, bool)"/>.
         /// </summary>
@@ -43,8 +34,10 @@ namespace MicaForEveryone.Win32
         /// <summary>
         /// Enable Mica on target window with <see cref="SetMica(IntPtr, bool)"/> or <see cref="SetBackdropType(IntPtr, DWM_SYSTEMBACKDROP_TYPE)"/> if supported.
         /// </summary>
+        /// <param name="hWnd">Handle of the target window for the operation.</param>
         public static void EnableMicaIfSupported(IntPtr hWnd)
         {
+
             if (IsBackdropTypeSupported)
             {
                 SetBackdropType(hWnd, DWM_SYSTEMBACKDROP_TYPE.DWMSBT_MAINWINDOW);
@@ -59,118 +52,92 @@ namespace MicaForEveryone.Win32
         /// Enable or Disable Mica on target window
         /// Supported on Windows builds from 22000 to 22523. It doesn't work on 22523, use <see cref="SetBackdropType(IntPtr, DWM_SYSTEMBACKDROP_TYPE)"/> instead.
         /// </summary>
+        /// <param name="hWnd">Handle of the target window for the operation.</param>
+        /// <param name="state"><see langword="true"/> to enable Mica effects on the target window, <see langword="false"/> to disable them.</param>
+        /// <seealso cref="SetBackdropType(IntPtr, DWM_SYSTEMBACKDROP_TYPE)"/>
         public static void SetMica(IntPtr hWnd, bool state)
         {
-            var value = GCHandle.Alloc(state ? 1 : 0, GCHandleType.Pinned);
-            var result = DwmSetWindowAttribute(hWnd, DWMWA_MICA, value.AddrOfPinnedObject(), sizeof(int));
-            value.Free();
-            if (result != 0)
-            {
-                throw Marshal.GetExceptionForHR(result);
-            }
+            SetWindowAttribute(hWnd, DwmWindowAttribute.DWMWA_MICA, state ? 1 : 0, sizeof(int));
         }
 
         /// <summary>
         /// Set backdrop type on target window
         /// Requires Windows build 22523 or higher.
         /// </summary>
+        /// <param name="hWnd">Handle of the target window for the operation.</param>
+        /// <param name="backdropType">Type of backdrop to apply to the target window's background.</param>
         public static void SetBackdropType(IntPtr hWnd, DWM_SYSTEMBACKDROP_TYPE backdropType)
         {
-            var value = GCHandle.Alloc((uint)backdropType, GCHandleType.Pinned);
-            var result = DwmSetWindowAttribute(hWnd, DWMWA_SYSTEMBACKDROP_TYPE, value.AddrOfPinnedObject(), sizeof(uint));
-            value.Free();
-            if (result != 0)
-            {
-                throw Marshal.GetExceptionForHR(result);
-            }
-
+            SetWindowAttribute(hWnd, DwmWindowAttribute.DWMWA_SYSTEMBACKDROP_TYPE, (uint)backdropType, sizeof(uint));
         }
-        
+
         /// <summary>
         /// Set corner preference on target window
         /// Requires Windows build 22000 or higher.
         /// </summary>
+        /// <param name="hWnd">Handle of the target window for the operation.</param>
+        /// <param name="cornerPreference">Corner preference to apply on the window's border.</param>
         public static void SetCornerPreference(IntPtr hWnd, DWM_WINDOW_CORNER_PREFERENCE cornerPreference)
         {
-            var value = GCHandle.Alloc((uint)cornerPreference, GCHandleType.Pinned);
-            var result = DwmSetWindowAttribute(hWnd, DWMWA_WINDOW_CORNER_PREFERENCE, value.AddrOfPinnedObject(), sizeof(uint));
-            value.Free();
-            if (result != 0)
-            {
-                throw Marshal.GetExceptionForHR(result);
-            }
-
+            SetWindowAttribute(hWnd, DwmWindowAttribute.DWMWA_WINDOW_CORNER_PREFERENCE, (uint)cornerPreference, sizeof(uint));
         }
-        
+
         /// <summary>
         /// Enable or disable immersive dark mode.
         /// Requires Windows build 19041 or higher.
         /// </summary>
-        public static void SetImmersiveDarkMode(IntPtr target, bool state)
+        /// <param name="hWnd">Handle of the target window for the operation.</param>
+        /// <param name="state"><see langword="true"/> to enable the immersive dark mode, <see langword="false"/> to disable it.</param>
+        public static void SetImmersiveDarkMode(IntPtr hWnd, bool state)
         {
-            var value = GCHandle.Alloc(state ? 1 : 0, GCHandleType.Pinned);
-            var result = DwmSetWindowAttribute(target, DWMWA_IMMERSIVE_DARK_MODE, value.AddrOfPinnedObject(), sizeof(int));
-            value.Free();
-            if (result != 0)
-            {
-                throw Marshal.GetExceptionForHR(result);
-            }
+            SetWindowAttribute(hWnd, DwmWindowAttribute.DWMWA_USE_IMMERSIVE_DARK_MODE, state ? 1 : 0, sizeof(int));
         }
 
-        public static void ExtendFrameIntoClientArea(IntPtr target)
+        /// <summary>
+        /// Extends the window's frame into the client area.
+        /// </summary>
+        /// <param name="hWnd">Handle of the target window for the operation.</param>
+        public static void ExtendFrameIntoClientArea(IntPtr hWnd)
         {
             var margins = new MARGINS(-1);
-            var result = DwmExtendFrameIntoClientArea(target, margins);
-            if (result != 0)
-            {
-                throw Marshal.GetExceptionForHR(result);
-            }
+            CheckHResult(DwmExtendFrameIntoClientArea(hWnd, margins));
         }
 
         /// <summary>
         /// Change background color of titlebar.
         /// Requires Windows build 22000 or higher.
         /// </summary>
+        /// <param name="hWnd">Handle of the target window for the operation.</param>
+        /// <param name="color">Color value to apply to the window's caption.</param>
         public static void SetCaptionColor(IntPtr hWnd, COLORREF color)
         {
             if (Environment.OSVersion.Version.Build < 22000)
                 return;
-            
-            var value = GCHandle.Alloc(color, GCHandleType.Pinned);
-            var result = DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, value.AddrOfPinnedObject(), Marshal.SizeOf(color));
-            value.Free();
-            if (result != 0)
-            {
-                throw Marshal.GetExceptionForHR(result);
-            }
+            SetWindowAttribute(hWnd, DwmWindowAttribute.DWMWA_CAPTION_COLOR, color, Marshal.SizeOf(color));
         }
 
         /// <summary>
         /// Change text color of titlebar.
         /// Requires Windows build 22000 or higher.
         /// </summary>
+        /// <param name="hWnd">Handle of the target window for the operation.</param>
+        /// <param name="color">Color value to apply to the window's caption text.</param>
         public static void SetCaptionTextColor(IntPtr hWnd, COLORREF color)
         {
             if (Environment.OSVersion.Version.Build < 22000)
                 return;
-            
-            var value = GCHandle.Alloc(color, GCHandleType.Pinned);
-            var result = DwmSetWindowAttribute(hWnd, DWMWA_TEXT_COLOR, value.AddrOfPinnedObject(), Marshal.SizeOf(color));
-            value.Free();
-            if (result != 0)
-            {
-                throw Marshal.GetExceptionForHR(result);
-            }
+
+            SetWindowAttribute(hWnd, DwmWindowAttribute.DWMWA_TEXT_COLOR, color, Marshal.SizeOf(color));
         }
 
-        public static void EnableBlurBehind(IntPtr target)
+        /// <summary>
+        /// Enables the Blur effects to be rendered in the window's background.
+        /// </summary>
+        /// <param name="hWnd">Handle of the target window for the operation.</param>
+        public static void EnableBlurBehind(IntPtr hWnd)
         {
             var value = new DWM_BLURBEHIND(true);
-            var result = DwmEnableBlurBehindWindow(target, value);
-            if (result != 0)
-            {
-                throw Marshal.GetExceptionForHR(result);
-            }
+            CheckHResult(DwmEnableBlurBehindWindow(hWnd, value));
 
             var accentPolicy = new AccentPolicy
             {
@@ -186,8 +153,24 @@ namespace MicaForEveryone.Win32
                 Data = accentPolicyPtr,
             };
             compositionAttributeData.SizeOfData = Marshal.SizeOf(compositionAttributeData);
-            SetWindowCompositionAttribute(target, ref compositionAttributeData);
+            var result = SetWindowCompositionAttribute(hWnd, ref compositionAttributeData);
             Marshal.FreeHGlobal(accentPolicyPtr);
+            CheckHResult(result);
+        }
+
+        private static void SetWindowAttribute<T>(IntPtr hWnd, DwmWindowAttribute attribute, T value, int sizeOf)
+        {
+            var pinnedValue = GCHandle.Alloc(value, GCHandleType.Pinned);
+            var valueAddr = pinnedValue.AddrOfPinnedObject();
+            var result = DwmSetWindowAttribute(hWnd, (uint)attribute, valueAddr, sizeOf);
+            pinnedValue.Free();
+            CheckHResult(result);
+        }
+
+        private static int CheckHResult(int result)
+        {
+            if (Marshal.GetExceptionForHR(result) is { } ex) throw ex;
+            return result;
         }
     }
 }

--- a/MicaForEveryone.Win32/DesktopWindowManager.cs
+++ b/MicaForEveryone.Win32/DesktopWindowManager.cs
@@ -3,6 +3,10 @@ using System;
 using System.Runtime.InteropServices;
 using static MicaForEveryone.Win32.PInvoke.NativeMethods;
 
+#if NET6_0_OR_GREATER
+using System.Runtime.Versioning;
+#endif
+
 namespace MicaForEveryone.Win32
 {
     public static class DesktopWindowManager
@@ -37,7 +41,9 @@ namespace MicaForEveryone.Win32
         /// <param name="hWnd">Handle of the target window for the operation.</param>
         public static void EnableMicaIfSupported(IntPtr hWnd)
         {
-
+#if NET6_0_OR_GREATER
+#pragma warning disable CA1416
+#endif
             if (IsBackdropTypeSupported)
             {
                 SetBackdropType(hWnd, DWM_SYSTEMBACKDROP_TYPE.DWMSBT_MAINWINDOW);
@@ -46,6 +52,9 @@ namespace MicaForEveryone.Win32
             {
                 SetMica(hWnd, true);
             }
+#if NET6_0_OR_GREATER
+#pragma warning restore CA1416
+#endif
         }
 
         /// <summary>
@@ -55,6 +64,10 @@ namespace MicaForEveryone.Win32
         /// <param name="hWnd">Handle of the target window for the operation.</param>
         /// <param name="state"><see langword="true"/> to enable Mica effects on the target window, <see langword="false"/> to disable them.</param>
         /// <seealso cref="SetBackdropType(IntPtr, DWM_SYSTEMBACKDROP_TYPE)"/>
+#if NET6_0_OR_GREATER
+        [SupportedOSPlatform("windows10.0.22000")]
+        [UnsupportedOSPlatform("windows10.0.22523")]
+# endif
         public static void SetMica(IntPtr hWnd, bool state)
         {
             SetWindowAttribute(hWnd, DwmWindowAttribute.DWMWA_MICA, state ? 1 : 0, sizeof(int));
@@ -66,6 +79,9 @@ namespace MicaForEveryone.Win32
         /// </summary>
         /// <param name="hWnd">Handle of the target window for the operation.</param>
         /// <param name="backdropType">Type of backdrop to apply to the target window's background.</param>
+#if NET6_0_OR_GREATER
+        [SupportedOSPlatform("windows10.0.22523")]
+#endif
         public static void SetBackdropType(IntPtr hWnd, DWM_SYSTEMBACKDROP_TYPE backdropType)
         {
             SetWindowAttribute(hWnd, DwmWindowAttribute.DWMWA_SYSTEMBACKDROP_TYPE, (uint)backdropType, sizeof(uint));
@@ -77,6 +93,9 @@ namespace MicaForEveryone.Win32
         /// </summary>
         /// <param name="hWnd">Handle of the target window for the operation.</param>
         /// <param name="cornerPreference">Corner preference to apply on the window's border.</param>
+#if NET6_0_OR_GREATER
+        [SupportedOSPlatform("windows10.0.22000")]
+#endif
         public static void SetCornerPreference(IntPtr hWnd, DWM_WINDOW_CORNER_PREFERENCE cornerPreference)
         {
             SetWindowAttribute(hWnd, DwmWindowAttribute.DWMWA_WINDOW_CORNER_PREFERENCE, (uint)cornerPreference, sizeof(uint));
@@ -88,6 +107,9 @@ namespace MicaForEveryone.Win32
         /// </summary>
         /// <param name="hWnd">Handle of the target window for the operation.</param>
         /// <param name="state"><see langword="true"/> to enable the immersive dark mode, <see langword="false"/> to disable it.</param>
+#if NET6_0_OR_GREATER
+        [SupportedOSPlatform("windows10.0.19041")]
+#endif
         public static void SetImmersiveDarkMode(IntPtr hWnd, bool state)
         {
             SetWindowAttribute(hWnd, DwmWindowAttribute.DWMWA_USE_IMMERSIVE_DARK_MODE, state ? 1 : 0, sizeof(int));
@@ -109,6 +131,9 @@ namespace MicaForEveryone.Win32
         /// </summary>
         /// <param name="hWnd">Handle of the target window for the operation.</param>
         /// <param name="color">Color value to apply to the window's caption.</param>
+#if NET6_0_OR_GREATER
+        [SupportedOSPlatform("windows10.0.22000")]
+#endif
         public static void SetCaptionColor(IntPtr hWnd, COLORREF color)
         {
             if (Environment.OSVersion.Version.Build < 22000)
@@ -122,6 +147,9 @@ namespace MicaForEveryone.Win32
         /// </summary>
         /// <param name="hWnd">Handle of the target window for the operation.</param>
         /// <param name="color">Color value to apply to the window's caption text.</param>
+#if NET6_0_OR_GREATER
+        [SupportedOSPlatform("windows10.0.22000")]
+#endif
         public static void SetCaptionTextColor(IntPtr hWnd, COLORREF color)
         {
             if (Environment.OSVersion.Version.Build < 22000)

--- a/MicaForEveryone.Win32/MicaForEveryone.Win32.csproj
+++ b/MicaForEveryone.Win32/MicaForEveryone.Win32.csproj
@@ -1,11 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
-        <LangVersion>9.0</LangVersion>
+        <TargetFrameworks>netstandard2.0;net6.0-windows</TargetFrameworks>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
         <Platforms>AnyCPU;x86;x64</Platforms>
+    </PropertyGroup>
+    
+    <PropertyGroup Condition="$(TargetFramework)=='netstandard2.0'">
+        <LangVersion>9.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/MicaForEveryone.Win32/PInvoke/DwmWindowAttribute.cs
+++ b/MicaForEveryone.Win32/PInvoke/DwmWindowAttribute.cs
@@ -1,0 +1,12 @@
+﻿namespace MicaForEveryone.Win32.PInvoke
+{
+    internal enum DwmWindowAttribute : uint
+    {
+        DWMWA_USE_IMMERSIVE_DARK_MODE = 20,
+        DWMWA_WINDOW_CORNER_PREFERENCE = 33,
+        DWMWA_CAPTION_COLOR = 35,
+        DWMWA_TEXT_COLOR = 36,
+        DWMWA_SYSTEMBACKDROP_TYPE = 38,
+        DWMWA_MICA = 1029,
+    }
+}

--- a/MicaForEveryone.Win32/Properties/AssemblyInfo.cs
+++ b/MicaForEveryone.Win32/Properties/AssemblyInfo.cs
@@ -4,3 +4,7 @@ using System.Reflection;
 [assembly: AssemblyProduct("Mica For Everyone Win32 Helper Library")]
 [assembly: AssemblyCompany("Mica For Everyone")]
 [assembly: AssemblyCopyright("Copyright (C) 2021-2022 Mohammad Amin Mollazadeh and Contributers")]
+
+#if NET6_0_OR_GREATER
+[assembly: System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif


### PR DESCRIPTION
This PR includes a small cleanup on the DesktopWindowManager class, reducing duplication for `DwmSetWindowAttribute` calls, as well as preliminary support for .NET 6 on the Win32 library (still unused by any projects in the solution as of yet) and `SupportedOSPlatform` attribute decorations, allowing for Windows API checks to be performed by the IDE. This last point could become especially useful if this component is ever provided as a NuGet package.