### PR TITLE
feat: Show app icon in rule list with auto-fetch, double-tap refresh and right-click clear

### DIFF
--- a/MicaForEveryone.App/App.xaml
+++ b/MicaForEveryone.App/App.xaml
@@ -18,6 +18,8 @@
                         <Setter Property="FontFamily" Value="{StaticResource SymbolThemeFontFamily}" />
                     </Style>
                     <helpers:ColorConverter x:Key="ColorConverter" />
+                    <helpers:PathToImageSourceConverter x:Key="PathToImageSourceConverter" />
+                    <helpers:NullToVisibilityConverter x:Key="NullToVisibilityConverter" />
                 </ResourceDictionary>
             </XamlControlsResources.MergedDictionaries>
         </XamlControlsResources>

--- a/MicaForEveryone.App/Helpers/IconHelper.cs
+++ b/MicaForEveryone.App/Helpers/IconHelper.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Drawing;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Media.Imaging;
+using TerraFX.Interop.Windows;
+using Windows.Storage.Streams;
+
+namespace MicaForEveryone.App.Helpers;
+
+public static class IconHelper
+{
+    private static readonly ConcurrentDictionary<string, BitmapImage> _cache = new();
+
+    private static string? _lastExtractedPath;
+
+    public static string? GetLastExtractedPath() => _lastExtractedPath;
+
+    public static async Task<Icon?> ExtractIconFromWindowAsync(HWND hwnd)
+    {
+        return await Task.Run(() =>
+        {
+            uint processId;
+            if (GetWindowThreadProcessId(hwnd, out processId) == 0 || processId == 0)
+                return null;
+
+            string? exePath = GetProcessExePath(processId);
+            if (exePath == null || !File.Exists(exePath))
+                return null;
+
+            _lastExtractedPath = exePath;
+
+            try
+            {
+                return Icon.ExtractAssociatedIcon(exePath);
+            }
+            catch
+            {
+                return null;
+            }
+        });
+    }
+
+    public static BitmapImage IconToBitmapImage(Icon icon)
+    {
+        using var bitmap = icon.ToBitmap();
+        using var ms = new MemoryStream();
+        bitmap.Save(ms, System.Drawing.Imaging.ImageFormat.Png);
+        ms.Position = 0;
+
+        var bitmapImage = new BitmapImage();
+        bitmapImage.SetSource(ms.AsRandomAccessStream());
+        return bitmapImage;
+    }
+
+    private static string? GetProcessExePath(uint processId)
+    {
+        IntPtr hProcess = IntPtr.Zero;
+        try
+        {
+            hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, processId);
+            if (hProcess == IntPtr.Zero)
+                return null;
+
+            var sb = new StringBuilder(260);
+            uint size = (uint)sb.Capacity;
+            if (QueryFullProcessImageName(hProcess, 0, sb, ref size))
+            {
+                return sb.ToString();
+            }
+        }
+        catch
+        {
+        }
+        finally
+        {
+            if (hProcess != IntPtr.Zero)
+                CloseHandle(hProcess);
+        }
+        return null;
+    }
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern uint GetWindowThreadProcessId(HWND hWnd, out uint lpdwProcessId);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr OpenProcess(uint dwDesiredAccess, bool bInheritHandle, uint dwProcessId);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CloseHandle(IntPtr hObject);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool QueryFullProcessImageName(IntPtr hProcess, uint dwFlags, StringBuilder lpExeName, ref uint lpdwSize);
+
+    private const uint PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
+}

--- a/MicaForEveryone.App/Helpers/MultiplyConverter.cs
+++ b/MicaForEveryone.App/Helpers/MultiplyConverter.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.UI.Xaml.Data;
+using System;
+
+namespace MicaForEveryone.App.Helpers;
+
+public partial class MultiplyConverter : IValueConverter
+{
+    public double Multiplier { get; set; } = 1.0;
+
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is double d)
+            return d * Multiplier;
+        return value;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/MicaForEveryone.App/Helpers/NullToVisibilityConverter.cs
+++ b/MicaForEveryone.App/Helpers/NullToVisibilityConverter.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+using System;
+
+namespace MicaForEveryone.App.Helpers;
+
+public partial class NullToVisibilityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        bool isNull = value is null or string { Length: 0 };
+        bool invert = parameter is string p && p.Equals("invert", StringComparison.OrdinalIgnoreCase);
+
+        if (invert)
+            return isNull ? Visibility.Collapsed : Visibility.Visible;
+        else
+            return isNull ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+        => throw new NotImplementedException();
+}

--- a/MicaForEveryone.App/Helpers/PathToImageSourceConverter.cs
+++ b/MicaForEveryone.App/Helpers/PathToImageSourceConverter.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.UI.Xaml.Data;
+using System;
+using System.IO;
+
+namespace MicaForEveryone.App.Helpers;
+
+public partial class PathToImageSourceConverter : IValueConverter
+{
+    public object? Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is string path && !string.IsNullOrEmpty(path) && File.Exists(path))
+        {
+            try
+            {
+                using var icon = System.Drawing.Icon.ExtractAssociatedIcon(path);
+                if (icon != null)
+                    return IconHelper.IconToBitmapImage(icon);
+            }
+            catch
+            {
+            }
+        }
+        return null;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+        => throw new NotImplementedException();
+}

--- a/MicaForEveryone.App/MicaForEveryone.App.csproj
+++ b/MicaForEveryone.App/MicaForEveryone.App.csproj
@@ -75,6 +75,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.251106002" />
+		<PackageReference Include="System.Drawing.Common" Version="10.0.8" />
 		<Manifest Include="$(ApplicationManifest)" />
 	</ItemGroup>
 

--- a/MicaForEveryone.App/ViewModels/AddClassRuleContentDialogViewModel.cs
+++ b/MicaForEveryone.App/ViewModels/AddClassRuleContentDialogViewModel.cs
@@ -2,8 +2,11 @@
 using CommunityToolkit.Mvvm.Input;
 using MicaForEveryone.CoreUI;
 using MicaForEveryone.Models;
+using Microsoft.UI.Xaml.Media;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using TerraFX.Interop.Windows;
+using MicaForEveryone.App.Helpers;
 
 namespace MicaForEveryone.App.ViewModels;
 
@@ -16,6 +19,9 @@ public partial class AddClassRuleContentDialogViewModel : ObservableObject
     [ObservableProperty]
     public partial IEnumerable<string>? Recommendations { get; set; }
 
+    [ObservableProperty]
+    public partial ImageSource? IconSource { get; set; }
+
     public bool IsAddButtonEnabled => !string.IsNullOrWhiteSpace(ClassName);
 
     private readonly ISettingsService _settingsService;
@@ -26,10 +32,44 @@ public partial class AddClassRuleContentDialogViewModel : ObservableObject
         ClassName = string.Empty;
     }
 
+    public async void TryFetchIcon(HWND hwnd)
+    {
+        try
+        {
+            var icon = await IconHelper.ExtractIconFromWindowAsync(hwnd);
+            if (icon != null)
+            {
+                var bitmapImage = IconHelper.IconToBitmapImage(icon);
+                icon.Dispose();
+                IconSource = bitmapImage;
+            }
+            else
+            {
+                IconSource = null;
+            }
+        }
+        catch
+        {
+            IconSource = null;
+        }
+    }
+
+    partial void OnClassNameChanged(string value)
+    {
+        IconSource = null;
+    }
+
     [RelayCommand]
     private async Task AddRuleAsync()
     {
-        _settingsService.Settings!.Rules.Insert(1, new ClassRule() { ClassName = ClassName });
+        var rule = new ClassRule() { ClassName = ClassName };
+
+        if (IconSource != null)
+        {
+            rule.IconPath = IconHelper.GetLastExtractedPath();
+        }
+
+        _settingsService.Settings!.Rules.Insert(1, rule);
         await _settingsService.SaveAsync();
     }
 }

--- a/MicaForEveryone.App/ViewModels/AddProcessRuleContentDialogViewModel.cs
+++ b/MicaForEveryone.App/ViewModels/AddProcessRuleContentDialogViewModel.cs
@@ -2,11 +2,14 @@
 using CommunityToolkit.Mvvm.Input;
 using MicaForEveryone.CoreUI;
 using MicaForEveryone.Models;
+using Microsoft.UI.Xaml.Media;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using TerraFX.Interop.Windows;
+using MicaForEveryone.App.Helpers;
 
 namespace MicaForEveryone.App.ViewModels;
 
@@ -19,6 +22,9 @@ public partial class AddProcessRuleContentDialogViewModel : ObservableObject
     [ObservableProperty]
     public partial ObservableCollection<string> Recommendations { get; set; }
 
+    [ObservableProperty]
+    public partial ImageSource? IconSource { get; set; }
+
     public bool IsAddButtonEnabled => !string.IsNullOrWhiteSpace(ProcessName);
 
     private readonly ISettingsService _settingsService;
@@ -28,6 +34,33 @@ public partial class AddProcessRuleContentDialogViewModel : ObservableObject
         _settingsService = settingsService;
         ProcessName = string.Empty;
         Recommendations = new ObservableCollection<string>();
+    }
+
+    public async void TryFetchIcon(HWND hwnd)
+    {
+        try
+        {
+            var icon = await IconHelper.ExtractIconFromWindowAsync(hwnd);
+            if (icon != null)
+            {
+                var bitmapImage = IconHelper.IconToBitmapImage(icon);
+                icon.Dispose();
+                IconSource = bitmapImage;
+            }
+            else
+            {
+                IconSource = null;
+            }
+        }
+        catch
+        {
+            IconSource = null;
+        }
+    }
+
+    partial void OnProcessNameChanged(string value)
+    {
+        IconSource = null;
     }
 
     public void RequestSuggestions()
@@ -60,7 +93,14 @@ public partial class AddProcessRuleContentDialogViewModel : ObservableObject
     [RelayCommand]
     private async Task AddRuleAsync()
     {
-        _settingsService.Settings!.Rules.Insert(1, new ProcessRule() { ProcessName = ProcessName });
+        var rule = new ProcessRule() { ProcessName = ProcessName };
+
+        if (IconSource != null)
+        {
+            rule.IconPath = IconHelper.GetLastExtractedPath();
+        }
+
+        _settingsService.Settings!.Rules.Insert(1, rule);
         await _settingsService.SaveAsync();
     }
 }

--- a/MicaForEveryone.App/Views/AddClassRuleContentDialog.xaml
+++ b/MicaForEveryone.App/Views/AddClassRuleContentDialog.xaml
@@ -7,19 +7,36 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:MicaForEveryone.App.Views"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:helpers="using:MicaForEveryone.App.Helpers"
     x:Uid="AddClassRuleDialog"
     DefaultButton="Primary"
     IsPrimaryButtonEnabled="{x:Bind ViewModel.IsAddButtonEnabled, Mode=OneWay}"
     PrimaryButtonCommand="{x:Bind ViewModel.AddRuleCommand}"
     mc:Ignorable="d">
 
+    <ContentDialog.Resources>
+        <helpers:MultiplyConverter x:Key="MultiplyConverter" Multiplier="0.75" />
+    </ContentDialog.Resources>
+    
     <ContentDialog.Style>
         <Style BasedOn="{StaticResource DefaultContentDialogStyle}" TargetType="local:AddClassRuleContentDialog" />
     </ContentDialog.Style>
 
-    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
-        <TextBox x:Uid="ClassTextBox" Text="{x:Bind ViewModel.ClassName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-        <controls:WindowPickerButton Grid.Column="1" WindowChanged="WindowPickerButton_WindowChanged">
+    <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
+        <Image Source="{x:Bind ViewModel.IconSource, Mode=OneWay}"
+               Height="{Binding ActualHeight, ElementName=ClassNameTextBox, 
+                       Converter={StaticResource MultiplyConverter}}"
+               Stretch="Uniform"
+               VerticalAlignment="Center"
+               Margin="0,0,4,0" />
+
+        <TextBox x:Name="ClassNameTextBox"
+                 Grid.Column="1"
+                 x:Uid="ClassTextBox"
+                 Text="{x:Bind ViewModel.ClassName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+        <controls:WindowPickerButton Grid.Column="2"
+                                     WindowChanged="WindowPickerButton_WindowChanged">
             <FontIcon Glyph="&#xF7ED;" />
         </controls:WindowPickerButton>
     </Grid>

--- a/MicaForEveryone.App/Views/AddClassRuleContentDialog.xaml.cs
+++ b/MicaForEveryone.App/Views/AddClassRuleContentDialog.xaml.cs
@@ -25,6 +25,7 @@ public sealed partial class AddClassRuleContentDialog : ContentDialog
         if (window == HWND.NULL)
         {
             ViewModel.ClassName = string.Empty;
+            ViewModel.IconSource = null;
             return;
         }
         char* lpClassName = stackalloc char[256];
@@ -34,5 +35,6 @@ public sealed partial class AddClassRuleContentDialog : ContentDialog
         }
         ReadOnlySpan<char> className = MemoryMarshal.CreateReadOnlySpanFromNullTerminated(lpClassName);
         ViewModel.ClassName = className.ToString();
+        ViewModel.TryFetchIcon(window);
     }
 }

--- a/MicaForEveryone.App/Views/AddProcessRuleContentDialog.xaml
+++ b/MicaForEveryone.App/Views/AddProcessRuleContentDialog.xaml
@@ -7,11 +7,16 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:MicaForEveryone.App.Views"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:helpers="using:MicaForEveryone.App.Helpers"
     x:Uid="AddProcessRuleDialog"
     DefaultButton="Primary"
     IsPrimaryButtonEnabled="{x:Bind ViewModel.IsAddButtonEnabled, Mode=OneWay}"
     PrimaryButtonCommand="{x:Bind ViewModel.AddRuleCommand}"
     mc:Ignorable="d">
+
+    <ContentDialog.Resources>
+        <helpers:MultiplyConverter x:Key="MultiplyConverter" Multiplier="0.75" />
+    </ContentDialog.Resources>
 
     <ContentDialog.Style>
         <Style BasedOn="{StaticResource DefaultContentDialogStyle}" TargetType="local:AddProcessRuleContentDialog" />
@@ -19,15 +24,27 @@
 
     <Grid ColumnSpacing="8">
         <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
             <ColumnDefinition />
             <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
-        <AutoSuggestBox
-            x:Uid="ProcessTextBox"
-            ItemsSource="{x:Bind ViewModel.Recommendations, Mode=OneWay}"
-            Text="{x:Bind ViewModel.ProcessName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-            TextChanged="AutoSuggestBox_TextChanged" />
-        <controls:WindowPickerButton Grid.Column="1" WindowChanged="WindowPickerButton_WindowChanged">
+
+        <Image Source="{x:Bind ViewModel.IconSource, Mode=OneWay}"
+               Height="{Binding ActualHeight, ElementName=ProcessNameBox, 
+                       Converter={StaticResource MultiplyConverter}}"
+               Stretch="Uniform"
+               VerticalAlignment="Center"
+               Margin="0,0,4,0" />
+
+        <AutoSuggestBox x:Name="ProcessNameBox"
+                        Grid.Column="1"
+                        x:Uid="ProcessTextBox"
+                        ItemsSource="{x:Bind ViewModel.Recommendations, Mode=OneWay}"
+                        Text="{x:Bind ViewModel.ProcessName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                        TextChanged="AutoSuggestBox_TextChanged" />
+
+        <controls:WindowPickerButton Grid.Column="2"
+                                     WindowChanged="WindowPickerButton_WindowChanged">
             <FontIcon Glyph="&#xF7ED;" />
         </controls:WindowPickerButton>
     </Grid>

--- a/MicaForEveryone.App/Views/AddProcessRuleContentDialog.xaml.cs
+++ b/MicaForEveryone.App/Views/AddProcessRuleContentDialog.xaml.cs
@@ -30,6 +30,7 @@ public sealed partial class AddProcessRuleContentDialog : ContentDialog
         if (window == HWND.NULL)
         {
             ViewModel.ProcessName = string.Empty;
+            ViewModel.IconSource = null;
             return;
         }
         uint procId;
@@ -42,6 +43,7 @@ public sealed partial class AddProcessRuleContentDialog : ContentDialog
         {
             Process proc = Process.GetProcessById((int)procId);
             ViewModel.ProcessName = proc.ProcessName;
+            ViewModel.TryFetchIcon(window);
         }
         catch { }
     }

--- a/MicaForEveryone.App/Views/RuleSettingsPage.xaml
+++ b/MicaForEveryone.App/Views/RuleSettingsPage.xaml
@@ -140,3 +140,4 @@
         </StackPanel>
     </controls:SettingsPageControl>
 </Page>
+    

--- a/MicaForEveryone.App/Views/RuleSettingsPage.xaml.cs
+++ b/MicaForEveryone.App/Views/RuleSettingsPage.xaml.cs
@@ -82,6 +82,8 @@ public sealed partial class RuleSettingsPage : Page
         SettingsService.Settings!.Rules.Remove(Rule!);
         _ = SettingsService.SaveAsync().ConfigureAwait(false);
         _ = RuleService.ApplyRulesToAllWindowsAsync().ConfigureAwait(false);
+
+        this.Frame?.Navigate(typeof(AppSettingsPage));
     }
 
     private void TitleBarCustomColorPicker_ButtonClicked(object sender, RoutedEventArgs e)

--- a/MicaForEveryone.App/Views/ShellPage.xaml.cs
+++ b/MicaForEveryone.App/Views/ShellPage.xaml.cs
@@ -1,28 +1,46 @@
 using MicaForEveryone.App.Controls.Navigation;
+using MicaForEveryone.App.Helpers;
 using MicaForEveryone.App.ViewModels;
 using MicaForEveryone.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 using System;
-using System.Diagnostics.CodeAnalysis;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using TerraFX.Interop.Windows;
+using WinRT;
+using NavigationViewItem = MicaForEveryone.App.Controls.Navigation.NavigationViewItem;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace MicaForEveryone.App.Views;
 
-/// <summary>
-/// An empty page that can be used on its own or navigated to within a Frame.
-/// </summary>
 public sealed partial class ShellPage : Page
 {
     private SettingsViewModel ViewModel { get; }
+    private readonly HashSet<NavigationViewItem> _eventAttachedItems = new();
 
     public ShellPage()
     {
         InitializeComponent();
         ViewModel = App.Services.GetRequiredService<SettingsViewModel>();
+
+        NavigationViewControl.Loaded += NavigationViewControl_Loaded;
+    }
+
+    private void NavigationViewControl_Loaded(object sender, RoutedEventArgs e)
+    {
+        NavigationViewControl.Loaded -= NavigationViewControl_Loaded;
+        LoadRuleIcons();
+        AttachRuleItemEvents();
     }
 
     private void TitleBarControl_PaneToggleRequested(TitleBar sender, object args)
@@ -46,6 +64,15 @@ public sealed partial class ShellPage : Page
         _contentFrame.Navigated -= _contentFrame_Navigated;
         TitleBarControl.PaneToggleRequested -= TitleBarControl_PaneToggleRequested;
         NavigationViewControl.SelectionChanged -= RuleListView_SelectionChanged;
+
+        // 解绑所有动态附加的事件
+        foreach (var item in _eventAttachedItems)
+        {
+            item.DoubleTapped -= RuleItem_DoubleTapped;
+            item.RightTapped -= RuleItem_RightTapped;
+        }
+        _eventAttachedItems.Clear();
+
         Bindings?.StopTracking();
 
         GC.Collect(2, GCCollectionMode.Forced, false, false);
@@ -59,18 +86,208 @@ public sealed partial class ShellPage : Page
         GC.Collect(2, GCCollectionMode.Forced, false, false);
     }
 
-    private void AddProcessRuleMenuFlyoutItem_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+    private async void AddProcessRuleMenuFlyoutItem_Click(object sender, RoutedEventArgs e)
     {
-        AddProcessRuleContentDialog addProcessRuleContentDialog = new();
-        addProcessRuleContentDialog.XamlRoot = XamlRoot;
-        _ = addProcessRuleContentDialog.ShowAsync();
+        var rules = ViewModel.SettingsService.Settings!.Rules;
+        AddProcessRuleContentDialog dialog = new();
+        dialog.XamlRoot = XamlRoot;
+        await dialog.ShowAsync();
+
+        if (rules.Count > 1)
+        {
+            var newRule = rules[1];
+            if (!string.IsNullOrEmpty(newRule.IconPath))
+                LoadIconForNewRule(newRule);
+        }
+
+        AttachEventsAfterLayout();
     }
 
-    private void AddClassRuleMenuFlyoutItem_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+    private async void AddClassRuleMenuFlyoutItem_Click(object sender, RoutedEventArgs e)
     {
-        AddClassRuleContentDialog addClassRuleContentDialog = new();
-        addClassRuleContentDialog.XamlRoot = XamlRoot;
-        _ = addClassRuleContentDialog.ShowAsync();
+        var rules = ViewModel.SettingsService.Settings!.Rules;
+        AddClassRuleContentDialog dialog = new();
+        dialog.XamlRoot = XamlRoot;
+        await dialog.ShowAsync();
+
+        if (rules.Count > 1)
+        {
+            var newRule = rules[1];
+            if (!string.IsNullOrEmpty(newRule.IconPath))
+                LoadIconForNewRule(newRule);
+        }
+
+        AttachEventsAfterLayout();
+    }
+
+    private void LoadIconForNewRule(Rule rule)
+    {
+        int retryCount = 0;
+        const int maxRetries = 10;
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        EventHandler<object>? onLayoutUpdated = null;
+        onLayoutUpdated = (sender, args) =>
+        {
+            retryCount++;
+            if (TryLoadIconForRule(rule) || retryCount >= maxRetries)
+            {
+                NavigationViewControl.LayoutUpdated -= onLayoutUpdated;
+                cts.Dispose();
+            }
+        };
+
+        NavigationViewControl.LayoutUpdated += onLayoutUpdated;
+
+        cts.Token.Register(() =>
+        {
+            NavigationViewControl.LayoutUpdated -= onLayoutUpdated;
+        });
+    }
+
+    private void AttachEventsAfterLayout()
+    {
+        EventHandler<object>? handler = null;
+        handler = (s, e) =>
+        {
+            NavigationViewControl.LayoutUpdated -= handler;
+            AttachRuleItemEvents();
+        };
+        NavigationViewControl.LayoutUpdated += handler;
+    }
+
+    private bool TryLoadIconForRule(Rule rule)
+    {
+        if (string.IsNullOrEmpty(rule.IconPath))
+            return true;
+
+        var navItem = FindVisualChildren<NavigationViewItem>(NavigationViewControl)
+            .FirstOrDefault(item => item.DataContext == rule);
+        if (navItem == null)
+            return false;
+
+        try
+        {
+            using var icon = System.Drawing.Icon.ExtractAssociatedIcon(rule.IconPath);
+            if (icon != null)
+            {
+                var bitmapImage = IconHelper.IconToBitmapImage(icon);
+                navItem.Icon = new ImageIcon { Source = bitmapImage };
+                return true;
+            }
+        }
+        catch { }
+        return false;
+    }
+
+    private void LoadRuleIcons()
+    {
+        foreach (var rule in ViewModel.SettingsService.Settings!.Rules)
+        {
+            if (!string.IsNullOrEmpty(rule.IconPath))
+                TryLoadIconForRule(rule);
+        }
+    }
+
+    private void AttachRuleItemEvents()
+    {
+        var items = FindVisualChildren<NavigationViewItem>(NavigationViewControl);
+        foreach (var item in items)
+        {
+            if (item.DataContext is Rule rule && rule is not GlobalRule)
+            {
+                AttachEventsToItem(item);
+            }
+        }
+    }
+
+    private void AttachEventsToItem(NavigationViewItem item)
+    {
+        if (_eventAttachedItems.Contains(item)) return;
+
+        item.DoubleTapped += RuleItem_DoubleTapped;
+        item.RightTapped += RuleItem_RightTapped;
+        _eventAttachedItems.Add(item);
+    }
+
+    private async void RuleItem_DoubleTapped(object sender, DoubleTappedRoutedEventArgs e)
+    {
+        if (sender is not NavigationViewItem navItem || navItem.DataContext is not Rule rule)
+            return;
+
+        if (rule is not ProcessRule processRule || string.IsNullOrEmpty(processRule.ProcessName))
+            return;
+
+        var processes = Process.GetProcessesByName(processRule.ProcessName);
+        var targetProcess = processes.FirstOrDefault(p => p.MainWindowHandle != IntPtr.Zero);
+        if (targetProcess == null) return;
+
+        HWND hwnd;
+        unsafe { hwnd = new HWND((void*)targetProcess.MainWindowHandle); }
+
+        var icon = await IconHelper.ExtractIconFromWindowAsync(hwnd);
+        if (icon != null)
+        {
+            using (icon)
+            {
+                string? iconPath = IconHelper.GetLastExtractedPath();
+                if (!string.IsNullOrEmpty(iconPath))
+                {
+                    rule.IconPath = iconPath;
+                    await ViewModel.SettingsService.SaveAsync();
+                    var bitmapImage = IconHelper.IconToBitmapImage(icon);
+                    navItem.Icon = new ImageIcon { Source = bitmapImage };
+                }
+            }
+        }
+    }
+
+    private async void RuleItem_RightTapped(object sender, RightTappedRoutedEventArgs e)
+    {
+        if (sender is not NavigationViewItem navItem || navItem.DataContext is not Rule rule)
+            return;
+        if (string.IsNullOrEmpty(rule.IconPath))
+            return;
+
+        rule.IconPath = null;
+        await ViewModel.SettingsService.SaveAsync();
+
+        if (rule is ProcessRule)
+            navItem.Icon = new FontIcon { Glyph = "\uECAA" };
+        else if (rule is ClassRule)
+            navItem.Icon = new FontIcon { Glyph = "\uE737" };
+    }
+
+    [DynamicWindowsRuntimeCast(typeof(FrameworkElement))]
+    private static T? FindChildByName<T>(DependencyObject parent, string name) where T : DependencyObject
+    {
+        int count = VisualTreeHelper.GetChildrenCount(parent);
+        for (int i = 0; i < count; i++)
+        {
+            var child = VisualTreeHelper.GetChild(parent, i);
+            if (child is T typedChild && (typedChild as FrameworkElement)?.Name == name)
+                return typedChild;
+
+            var result = FindChildByName<T>(child, name);
+            if (result != null)
+                return result;
+        }
+        return null;
+    }
+
+    private static IEnumerable<T> FindVisualChildren<T>(DependencyObject parent) where T : DependencyObject
+    {
+        if (parent == null) yield break;
+        int count = VisualTreeHelper.GetChildrenCount(parent);
+        for (int i = 0; i < count; i++)
+        {
+            var child = VisualTreeHelper.GetChild(parent, i);
+            if (child is T tChild)
+                yield return tChild;
+
+            foreach (var descendant in FindVisualChildren<T>(child))
+                yield return descendant;
+        }
     }
 }
 

--- a/MicaForEveryone.Models/Rule.cs
+++ b/MicaForEveryone.Models/Rule.cs
@@ -28,6 +28,9 @@ public abstract partial class Rule: ObservableObject, IEquatable<Rule>
     [ObservableProperty]
     public partial string? TitleBarColorCode { get; set; }
 
+    [ObservableProperty]
+    public partial string? IconPath { get; set; }
+
     [JsonIgnore]
     public abstract int Priority { get; }
     


### PR DESCRIPTION
## Description

This PR implements the feature request #542 - Show app icon in rule list.

## Changes

- Added `IconPath` property to `Rule` model for persisting extracted icon path
- Modified `AddProcessRuleContentDialog` and `AddClassRuleContentDialog` to preview app icon when selecting window via picker
- Added `IconHelper` utility class for extracting icons from window handles (HWND) and converting to `BitmapImage`
- Modified `ShellPage` to display icons in the left navigation rule list, replacing the default `FontIcon` (┏)
- Implemented double-tap to refresh icon from running process (ProcessRule only)
- Implemented right-click to clear icon and restore default FontIcon
- Used `LayoutUpdated` event with retry mechanism for loading icons of newly added rules
- Delete rule now navigates to settings page instead of leaving zombie view

## Testing

- [x] Icon preview works when using window picker in rule creation dialog
- [x] Manual text input clears icon preview
- [x] Saved rules show app icon in navigation list
- [x] Double-tap refreshes icon for running processes
- [x] Right-click clears icon and restores default
- [x] Delete rule navigates to settings page
- [x] Icons persist across application restarts
- [x] No crashes or exceptions during normal usage

## Screenshots

<img width="666" height="446" alt="MFE_01" src="https://github.com/user-attachments/assets/73a2e70a-c904-495a-9923-0f836bde641a" />
<img width="666" height="446" alt="MFE_02" src="https://github.com/user-attachments/assets/e9d745b9-ad46-4c24-a83c-468ed52ceecb" />

## Notes

- Icon extraction may fail for processes running with higher privileges than MFE (e.g., admin apps). This is a Windows security limitation and is handled gracefully by showing the default icon.
- Class rules do not support auto-fetching icons (double-tap) due to inability to determine the executable path from a class name alone.